### PR TITLE
add switch apsv_show_progress to disable progress percentage text

### DIFF
--- a/arcprogressstackview/src/main/java/devlight/io/library/ArcProgressStackView.java
+++ b/arcprogressstackview/src/main/java/devlight/io/library/ArcProgressStackView.java
@@ -149,6 +149,7 @@ public class ArcProgressStackView extends View {
     private boolean mIsRounded;
     private boolean mIsDragged;
     private boolean mIsModelBgEnabled;
+    private boolean mIsShowProgress;
     private boolean mIsLeveled;
 
     // Colors
@@ -269,6 +270,11 @@ public class ArcProgressStackView extends View {
             setModelBgEnabled(
                     typedArray.getBoolean(
                             R.styleable.ArcProgressStackView_apsv_model_bg_enabled, false
+                    )
+            );
+            setShowProgress(
+                    typedArray.getBoolean(
+                            R.styleable.ArcProgressStackView_apsv_show_progress, true
                     )
             );
 
@@ -453,6 +459,15 @@ public class ArcProgressStackView extends View {
 
     public void setModelBgEnabled(final boolean modelBgEnabled) {
         mIsModelBgEnabled = modelBgEnabled;
+        postInvalidate();
+    }
+
+    public boolean isShowProgress() {
+        return mIsShowProgress;
+    }
+
+    public void setShowProgress(final boolean showProgress) {
+        mIsShowProgress = showProgress;
         postInvalidate();
     }
 
@@ -977,12 +992,14 @@ public class ArcProgressStackView extends View {
                 // Draw progress value
                 canvas.save();
                 canvas.rotate(indicatorProgressAngle, model.mPos[0], model.mPos[1]);
-                canvas.drawText(
-                        percentProgress,
-                        model.mPos[0] - model.mTextBounds.exactCenterX(),
-                        model.mPos[1] - model.mTextBounds.exactCenterY(),
-                        mTextPaint
-                );
+                if (mIsShowProgress) {
+                    canvas.drawText(
+                            percentProgress,
+                            model.mPos[0] - model.mTextBounds.exactCenterX(),
+                            model.mPos[1] - model.mTextBounds.exactCenterY(),
+                            mTextPaint
+                    );
+                }
                 canvas.restore();
             }
 

--- a/arcprogressstackview/src/main/res/values/attrs.xml
+++ b/arcprogressstackview/src/main/res/values/attrs.xml
@@ -35,6 +35,7 @@ limitations under the License.
         <attr name="apsv_draw_width" format="fraction|dimension"/>
         <attr name="apsv_model_offset" format="dimension"/>
         <attr name="apsv_model_bg_enabled" format="boolean"/>
+        <attr name="apsv_show_progress" format="boolean"/>
 
         <attr name="apsv_start_angle" format="integer"/>
         <attr name="apsv_sweep_angle" format="integer"/>


### PR DESCRIPTION
Sometimes, the title text is all you need, and the fixed percentage display is distracting.